### PR TITLE
Django Example App Update to Python 3.6

### DIFF
--- a/openshift/templates/django-postgresql-persistent.json
+++ b/openshift/templates/django-postgresql-persistent.json
@@ -329,7 +329,7 @@
               "from": {
                 "kind": "ImageStreamTag",
                 "namespace": "${NAMESPACE}",
-                "name": "postgresql:9.5"
+                "name": "postgresql:${POSTGRESQL_VERSION}"
               }
             }
           },
@@ -442,6 +442,13 @@
       "displayName": "Version of Python Image",
       "description": "Version of Python image to be used (3.4, 3.5, 3.6 or latest).",
       "value": "3.6",
+      "required": true
+    },
+    {
+      "name": "POSTGRESQL_VERSION",
+      "displayName": "Version of PostgreSQL Image",
+      "description": "Version of PostgreSQL image to be used (9.4, 9.5, 9.6 or latest).",
+      "value": "9.6",
       "required": true
     },
     {

--- a/openshift/templates/django-postgresql-persistent.json
+++ b/openshift/templates/django-postgresql-persistent.json
@@ -105,7 +105,7 @@
             "from": {
               "kind": "ImageStreamTag",
               "namespace": "${NAMESPACE}",
-              "name": "python:3.5"
+              "name": "python:${PYTHON_VERSION}"
             },
             "env": [
               {
@@ -436,6 +436,13 @@
       "required": true,
       "description": "The OpenShift Namespace where the ImageStream resides.",
       "value": "openshift"
+    },
+    {
+      "name": "PYTHON_VERSION",
+      "displayName": "Version of Python Image",
+      "description": "Version of Python image to be used (3.4, 3.5, 3.6 or latest).",
+      "value": "3.6",
+      "required": true
     },
     {
       "name": "MEMORY_LIMIT",

--- a/openshift/templates/django-postgresql.json
+++ b/openshift/templates/django-postgresql.json
@@ -105,7 +105,7 @@
             "from": {
               "kind": "ImageStreamTag",
               "namespace": "${NAMESPACE}",
-              "name": "python:3.5"
+              "name": "python:${PYTHON_VERSION}"
             },
             "env": [
               {
@@ -417,6 +417,13 @@
       "required": true,
       "description": "The OpenShift Namespace where the ImageStream resides.",
       "value": "openshift"
+    },
+    {
+      "name": "PYTHON_VERSION",
+      "displayName": "Version of Python Image",
+      "description": "Version of Python image to be used (3.4, 3.5, 3.6 or latest).",
+      "value": "3.6",
+      "required": true
     },
     {
       "name": "MEMORY_LIMIT",

--- a/openshift/templates/django-postgresql.json
+++ b/openshift/templates/django-postgresql.json
@@ -312,7 +312,7 @@
               "from": {
                 "kind": "ImageStreamTag",
                 "namespace": "${NAMESPACE}",
-                "name": "postgresql:9.5"
+                "name": "postgresql:${POSTGRESQL_VERSION}"
               }
             }
           },
@@ -423,6 +423,13 @@
       "displayName": "Version of Python Image",
       "description": "Version of Python image to be used (3.4, 3.5, 3.6 or latest).",
       "value": "3.6",
+      "required": true
+    },
+    {
+      "name": "POSTGRESQL_VERSION",
+      "displayName": "Version of PostgreSQL Image",
+      "description": "Version of PostgreSQL image to be used (9.4, 9.5, 9.6 or latest).",
+      "value": "9.6",
       "required": true
     },
     {

--- a/openshift/templates/django.json
+++ b/openshift/templates/django.json
@@ -102,7 +102,7 @@
             "from": {
               "kind": "ImageStreamTag",
               "namespace": "${NAMESPACE}",
-              "name": "python:3.5"
+              "name": "python:${PYTHON_VERSION}"
             },
             "env": [
               {
@@ -247,6 +247,13 @@
       "required": true,
       "description": "The OpenShift Namespace where the ImageStream resides.",
       "value": "openshift"
+    },
+    {
+      "name": "PYTHON_VERSION",
+      "displayName": "Version of Python Image",
+      "description": "Version of Python image to be used (3.4, 3.5, 3.6 or latest).",
+      "value": "3.6",
+      "required": true
     },
     {
       "name": "MEMORY_LIMIT",


### PR DESCRIPTION
Except $subject, this also adds parameters `PYTHON_VERSION` and `POSTGRESQL_VERSION` that allow to change the version of the images used in the template and use the same image for more images combinations.

However, PostgreSQL 9.6 is not yet in the image streams, so merging this PR should wait till it is there.