### PR TITLE
Use postgresql's readycheck in templates

### DIFF
--- a/openshift/templates/django-postgresql-persistent.json
+++ b/openshift/templates/django-postgresql-persistent.json
@@ -400,14 +400,14 @@
                   "timeoutSeconds": 1,
                   "initialDelaySeconds": 5,
                   "exec": {
-                    "command": [ "/bin/sh", "-i", "-c", "psql -h 127.0.0.1 -U ${POSTGRESQL_USER} -q -d ${POSTGRESQL_DATABASE} -c 'SELECT 1'"]
+                    "command": [ "/usr/libexec/check-container" ]
                   }
                 },
                 "livenessProbe": {
-                  "timeoutSeconds": 1,
-                  "initialDelaySeconds": 30,
-                  "tcpSocket": {
-                    "port": 5432
+                  "timeoutSeconds": 10,
+                  "initialDelaySeconds": 120,
+                  "exec": {
+                    "command": [ "/usr/libexec/check-container", "--live" ]
                   }
                 },
                 "resources": {

--- a/openshift/templates/django-postgresql.json
+++ b/openshift/templates/django-postgresql.json
@@ -381,14 +381,14 @@
                   "timeoutSeconds": 1,
                   "initialDelaySeconds": 5,
                   "exec": {
-                    "command": [ "/bin/sh", "-i", "-c", "psql -h 127.0.0.1 -U ${POSTGRESQL_USER} -q -d ${POSTGRESQL_DATABASE} -c 'SELECT 1'"]
+                    "command": [ "/usr/libexec/check-container" ]
                   }
                 },
                 "livenessProbe": {
-                  "timeoutSeconds": 1,
-                  "initialDelaySeconds": 30,
-                  "tcpSocket": {
-                    "port": 5432
+                  "timeoutSeconds": 10,
+                  "initialDelaySeconds": 120,
+                  "exec": {
+                    "command": [ "/usr/libexec/check-container", "--live" ]
                   }
                 },
                 "resources": {


### PR DESCRIPTION
Note that the rhel version of the image containing the `check-container` script is not available yet.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1474683