### PR TITLE
Added instruction to set content type when configuring github webhook

### DIFF
--- a/welcome/templates/welcome/index.html
+++ b/welcome/templates/welcome/index.html
@@ -236,6 +236,7 @@ pre {
   <li>Click the "Copy to clipboard" icon to the right of the "GitHub webhook URL" field</li>
   <li>Navigate to your repository on GitHub and click on repository settings &gt; webhooks &gt; Add webhook</li>
   <li>Paste your webhook URL provided by OpenShift</li>
+  <li>From the "Content Type" dropdown, select "application/json"</li>
   <li>Leave the defaults for the remaining fields &mdash; that's it!</li>
 </ol>
 <p>After you save your webhook, if you refresh your settings page you can see the status of the ping that Github sent to OpenShift to verify it can reach the server.</p>


### PR DESCRIPTION
I was trying the Django sample and the Webhook wasn't working. Later I figured out that Content Type needs to be set.