### PR TITLE
Update psycopg2 to v2.8.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 django>=1.11,<1.12
 django-debug-toolbar==1.8
 gunicorn==19.4.5
-psycopg2==2.7.3.1
+psycopg2==2.8.5
 whitenoise==3.3.1


### PR DESCRIPTION
When using the image `docker.io/centos/python-36-centos7:latest`, `psycopg2==2.7.3.1` fails. Using the newest version, solves the problem.

The failure:

```
$ docker run -it --rm docker.io/centos/python-38-centos7:latest pip install psycopg2==2.7.3.1
WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ReadTimeoutError("HTTPSConnectionPool(host='pypi.org', port=443): Read timed out. (read timeout=15)")': /simple/psycopg2/
Collecting psycopg2==2.7.3.1
  Downloading https://files.pythonhosted.org/packages/6b/fb/15c687eda2f925f0ff59373063fdb408471b4284714a7761daaa65c01f15/psycopg2-2.7.3.1.tar.gz (425kB)
     |████████████████████████████████| 430kB 1.8MB/s 
Installing collected packages: psycopg2
    Running setup.py install for psycopg2 ... error
    ERROR: Command errored out with exit status 1:
     command: /opt/app-root/bin/python3.8 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-43ld5zcy/psycopg2/setup.py'"'"'; __file__='"'"'/tmp/pip-install-43ld5zcy/psycopg2/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-16u_0z4k/install-record.txt --single-version-externally-managed --compile --install-headers /opt/app-root/include/site/python3.8/psycopg2
         cwd: /tmp/pip-install-43ld5zcy/psycopg2/
    Complete output (65 lines):
    running install
    running build
    running build_py
    creating build
    creating build/lib.linux-x86_64-3.8
    creating build/lib.linux-x86_64-3.8/psycopg2
    copying lib/_range.py -> build/lib.linux-x86_64-3.8/psycopg2
    copying lib/sql.py -> build/lib.linux-x86_64-3.8/psycopg2
    copying lib/__init__.py -> build/lib.linux-x86_64-3.8/psycopg2
    copying lib/extensions.py -> build/lib.linux-x86_64-3.8/psycopg2
    copying lib/_json.py -> build/lib.linux-x86_64-3.8/psycopg2
    copying lib/tz.py -> build/lib.linux-x86_64-3.8/psycopg2
    copying lib/psycopg1.py -> build/lib.linux-x86_64-3.8/psycopg2
    copying lib/extras.py -> build/lib.linux-x86_64-3.8/psycopg2
    copying lib/errorcodes.py -> build/lib.linux-x86_64-3.8/psycopg2
    copying lib/_ipaddress.py -> build/lib.linux-x86_64-3.8/psycopg2
    copying lib/pool.py -> build/lib.linux-x86_64-3.8/psycopg2
    creating build/lib.linux-x86_64-3.8/psycopg2/tests
    copying tests/test_fast_executemany.py -> build/lib.linux-x86_64-3.8/psycopg2/tests
    copying tests/test_ipaddress.py -> build/lib.linux-x86_64-3.8/psycopg2/tests
    copying tests/__init__.py -> build/lib.linux-x86_64-3.8/psycopg2/tests
    copying tests/test_replication.py -> build/lib.linux-x86_64-3.8/psycopg2/tests
    copying tests/test_lobject.py -> build/lib.linux-x86_64-3.8/psycopg2/tests
    copying tests/test_async.py -> build/lib.linux-x86_64-3.8/psycopg2/tests
    copying tests/test_types_basic.py -> build/lib.linux-x86_64-3.8/psycopg2/tests
    copying tests/test_connection.py -> build/lib.linux-x86_64-3.8/psycopg2/tests
    copying tests/test_transaction.py -> build/lib.linux-x86_64-3.8/psycopg2/tests
    copying tests/testutils.py -> build/lib.linux-x86_64-3.8/psycopg2/tests
    copying tests/test_extras_dictcursor.py -> build/lib.linux-x86_64-3.8/psycopg2/tests
    copying tests/test_sql.py -> build/lib.linux-x86_64-3.8/psycopg2/tests
    copying tests/test_errcodes.py -> build/lib.linux-x86_64-3.8/psycopg2/tests
    copying tests/test_async_keyword.py -> build/lib.linux-x86_64-3.8/psycopg2/tests
    copying tests/test_copy.py -> build/lib.linux-x86_64-3.8/psycopg2/tests
    copying tests/test_green.py -> build/lib.linux-x86_64-3.8/psycopg2/tests
    copying tests/test_cancel.py -> build/lib.linux-x86_64-3.8/psycopg2/tests
    copying tests/test_bugX000.py -> build/lib.linux-x86_64-3.8/psycopg2/tests
    copying tests/test_psycopg2_dbapi20.py -> build/lib.linux-x86_64-3.8/psycopg2/tests
    copying tests/test_bug_gc.py -> build/lib.linux-x86_64-3.8/psycopg2/tests
    copying tests/test_quote.py -> build/lib.linux-x86_64-3.8/psycopg2/tests
    copying tests/dbapi20_tpc.py -> build/lib.linux-x86_64-3.8/psycopg2/tests
    copying tests/test_types_extras.py -> build/lib.linux-x86_64-3.8/psycopg2/tests
    copying tests/test_notify.py -> build/lib.linux-x86_64-3.8/psycopg2/tests
    copying tests/test_module.py -> build/lib.linux-x86_64-3.8/psycopg2/tests
    copying tests/test_with.py -> build/lib.linux-x86_64-3.8/psycopg2/tests
    copying tests/test_dates.py -> build/lib.linux-x86_64-3.8/psycopg2/tests
    copying tests/testconfig.py -> build/lib.linux-x86_64-3.8/psycopg2/tests
    copying tests/test_cursor.py -> build/lib.linux-x86_64-3.8/psycopg2/tests
    copying tests/dbapi20.py -> build/lib.linux-x86_64-3.8/psycopg2/tests
    Skipping optional fixer: buffer
    Skipping optional fixer: idioms
    Skipping optional fixer: set_literal
    Skipping optional fixer: ws_comma
    running build_ext
    building 'psycopg2._psycopg' extension
    creating build/temp.linux-x86_64-3.8
    creating build/temp.linux-x86_64-3.8/psycopg
    gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -I/opt/rh/rh-python38/root/usr/include -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -I/opt/rh/rh-python38/root/usr/include -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -fPIC -DPSYCOPG_DEFAULT_PYDATETIME=1 -DPSYCOPG_VERSION="2.7.3.1 (dt dec pq3 ext)" -DPG_VERSION_NUM=90224 -I/opt/app-root/include -I/opt/rh/rh-python38/root/usr/include/python3.8 -I. -I/usr/include -I/usr/include/pgsql/server -c psycopg/psycopgmodule.c -o build/temp.linux-x86_64-3.8/psycopg/psycopgmodule.o -Wdeclaration-after-statement
    psycopg/psycopgmodule.c: In function ‘psyco_is_main_interp’:
    psycopg/psycopgmodule.c:685:18: error: dereferencing pointer to incomplete type
         while (interp->next)
                      ^
    psycopg/psycopgmodule.c:686:24: error: dereferencing pointer to incomplete type
             interp = interp->next;
                            ^
    error: command 'gcc' failed with exit status 1
    ----------------------------------------
ERROR: Command errored out with exit status 1: /opt/app-root/bin/python3.8 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-43ld5zcy/psycopg2/setup.py'"'"'; __file__='"'"'/tmp/pip-install-43ld5zcy/psycopg2/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-16u_0z4k/install-record.txt --single-version-externally-managed --compile --install-headers /opt/app-root/include/site/python3.8/psycopg2 Check the logs for full command output.
```