### PR TITLE
Move from psycopg2 to psycopg2-binary to use manylinux wheels

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 django>=1.11,<1.12
 django-debug-toolbar==1.8
 gunicorn==19.5.0
-psycopg2==2.7.3.1
+psycopg2-binary==2.7.3.2
 whitenoise==3.3.1


### PR DESCRIPTION
For more details, see https://github.com/psycopg/psycopg2/issues/674

Cc: @phracek 