### PR TITLE
Move from psycopg2 to psycopg2-binary to use manylinux wheels

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django>=2.2.12,<3.0
 django-debug-toolbar==2.2
 gunicorn==20.0.4
-psycopg2==2.8.5
+psycopg2-binary==2.8.5
 pytz==2020.1
 sqlparse==0.3.1
 whitenoise==5.1.0


### PR DESCRIPTION
For more details, see https://github.com/psycopg/psycopg2/issues/674

Cc: @phracek 