### PR TITLE
Update psycopg2-binary to version 2.8.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 django>=1.11,<1.12
 django-debug-toolbar==1.8
 gunicorn==19.5.0
-psycopg2-binary==2.7.3.2
+psycopg2-binary==2.8.5
 whitenoise==3.3.1


### PR DESCRIPTION
2.8.4 is the first version providing manylinux wheels for
Python 3.8 so it should make no difference if we update it
to the latest version 2.8.5.

Cc: @phracek 