### PR TITLE
Update templates to 3.8

### DIFF
--- a/openshift/templates/django-postgresql-persistent.json
+++ b/openshift/templates/django-postgresql-persistent.json
@@ -440,8 +440,8 @@
     {
       "name": "PYTHON_VERSION",
       "displayName": "Version of Python Image",
-      "description": "Version of Python image to be used (3.6-ubi7, 3.6-ubi8, or latest).",
-      "value": "3.6-ubi8",
+      "description": "Version of Python image to be used (3.6-ubi8, 3.8-ubi7, 3.8-ubi8, or latest).",
+      "value": "3.8-ubi8",
       "required": true
     },
     {

--- a/openshift/templates/django-postgresql.json
+++ b/openshift/templates/django-postgresql.json
@@ -421,8 +421,8 @@
     {
       "name": "PYTHON_VERSION",
       "displayName": "Version of Python Image",
-      "description": "Version of Python image to be used (3.6-ubi7, 3.6-ubi8, or latest).",
-      "value": "3.6-ubi8",
+      "description": "Version of Python image to be used (3.6-ubi8, 3.8-ubi7, 3.8-ubi8, or latest).",
+      "value": "3.8-ubi8",
       "required": true
     },
     {

--- a/openshift/templates/django.json
+++ b/openshift/templates/django.json
@@ -251,8 +251,8 @@
     {
       "name": "PYTHON_VERSION",
       "displayName": "Version of Python Image",
-      "description": "Version of Python image to be used (3.6-ubi7, 3.6-ubi8, or latest).",
-      "value": "3.6-ubi8",
+      "description": "Version of Python image to be used (3.6-ubi8, 3.8-ubi7, 3.8-ubi8, or latest).",
+      "value": "3.8-ubi8",
       "required": true
     },
     {


### PR DESCRIPTION
3.6-ubi7 is going EOL too:

https://github.com/sclorg/s2i-python-container/pull/398#issuecomment-692965551