### PR TITLE
Update pyscopg2-binary to 2.8.6 for Python 3.9 wheels

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django>=2.2.12,<3.0
 django-debug-toolbar==2.2
 gunicorn==20.0.4
-psycopg2-binary==2.8.5
+psycopg2-binary==2.8.6
 pytz==2020.1
 sqlparse==0.3.1
 whitenoise==5.1.0


### PR DESCRIPTION
For testing with Python 3.9, it!d be better to use the version which provides binary wheels for 3.9.