### PR TITLE
[3.2.x] Update templates to 3.9, use groupified apiVersion

### DIFF
--- a/openshift/templates/django-postgresql-persistent.json
+++ b/openshift/templates/django-postgresql-persistent.json
@@ -1,6 +1,6 @@
 {
   "kind": "Template",
-  "apiVersion": "v1",
+  "apiVersion": "template.openshift.io/v1",
   "metadata": {
     "name": "django-psql-persistent",
     "annotations": {
@@ -58,7 +58,7 @@
     },
     {
       "kind": "Route",
-      "apiVersion": "v1",
+      "apiVersion": "route.openshift.io/v1",
       "metadata": {
         "name": "${NAME}"
       },
@@ -72,7 +72,7 @@
     },
     {
       "kind": "ImageStream",
-      "apiVersion": "v1",
+      "apiVersion": "image.openshift.io/v1",
       "metadata": {
         "name": "${NAME}",
         "annotations": {
@@ -82,7 +82,7 @@
     },
     {
       "kind": "BuildConfig",
-      "apiVersion": "v1",
+      "apiVersion": "build.openshift.io/v1",
       "metadata": {
         "name": "${NAME}",
         "annotations": {
@@ -142,7 +142,7 @@
     },
     {
       "kind": "DeploymentConfig",
-      "apiVersion": "v1",
+      "apiVersion": "apps.openshift.io/v1",
       "metadata": {
         "name": "${NAME}",
         "annotations": {
@@ -306,7 +306,7 @@
     },
     {
       "kind": "DeploymentConfig",
-      "apiVersion": "v1",
+      "apiVersion": "apps.openshift.io/v1",
       "metadata": {
         "name": "${DATABASE_SERVICE_NAME}",
         "annotations": {

--- a/openshift/templates/django-postgresql-persistent.json
+++ b/openshift/templates/django-postgresql-persistent.json
@@ -440,8 +440,8 @@
     {
       "name": "PYTHON_VERSION",
       "displayName": "Version of Python Image",
-      "description": "Version of Python image to be used (3.6-ubi8, 3.8-ubi8, or latest).",
-      "value": "3.8-ubi8",
+      "description": "Version of Python image to be used (3.6-ubi8, 3.8-ubi8, 3.9-ubi8, or latest).",
+      "value": "3.9-ubi8",
       "required": true
     },
     {

--- a/openshift/templates/django-postgresql.json
+++ b/openshift/templates/django-postgresql.json
@@ -1,6 +1,6 @@
 {
   "kind": "Template",
-  "apiVersion": "v1",
+  "apiVersion": "template.openshift.io/v1",
   "metadata": {
     "name": "django-psql-example",
     "annotations": {
@@ -58,7 +58,7 @@
     },
     {
       "kind": "Route",
-      "apiVersion": "v1",
+      "apiVersion": "route.openshift.io/v1",
       "metadata": {
         "name": "${NAME}"
       },
@@ -72,7 +72,7 @@
     },
     {
       "kind": "ImageStream",
-      "apiVersion": "v1",
+      "apiVersion": "image.openshift.io/v1",
       "metadata": {
         "name": "${NAME}",
         "annotations": {
@@ -82,7 +82,7 @@
     },
     {
       "kind": "BuildConfig",
-      "apiVersion": "v1",
+      "apiVersion": "build.openshift.io/v1",
       "metadata": {
         "name": "${NAME}",
         "annotations": {
@@ -142,7 +142,7 @@
     },
     {
       "kind": "DeploymentConfig",
-      "apiVersion": "v1",
+      "apiVersion": "apps.openshift.io/v1",
       "metadata": {
         "name": "${NAME}",
         "annotations": {
@@ -289,7 +289,7 @@
     },
     {
       "kind": "DeploymentConfig",
-      "apiVersion": "v1",
+      "apiVersion": "apps.openshift.io/v1",
       "metadata": {
         "name": "${DATABASE_SERVICE_NAME}",
         "annotations": {

--- a/openshift/templates/django-postgresql.json
+++ b/openshift/templates/django-postgresql.json
@@ -421,8 +421,8 @@
     {
       "name": "PYTHON_VERSION",
       "displayName": "Version of Python Image",
-      "description": "Version of Python image to be used (3.6-ubi8, 3.8-ubi8, or latest).",
-      "value": "3.8-ubi8",
+      "description": "Version of Python image to be used (3.6-ubi8, 3.8-ubi8, 3.9-ubi8, or latest).",
+      "value": "3.9-ubi8",
       "required": true
     },
     {

--- a/openshift/templates/django.json
+++ b/openshift/templates/django.json
@@ -1,6 +1,6 @@
 {
   "kind": "Template",
-  "apiVersion": "v1",
+  "apiVersion": "template.openshift.io/v1",
   "metadata": {
     "name": "django-example",
     "annotations": {
@@ -55,7 +55,7 @@
     },
     {
       "kind": "Route",
-      "apiVersion": "v1",
+      "apiVersion": "route.openshift.io/v1",
       "metadata": {
         "name": "${NAME}"
       },
@@ -69,7 +69,7 @@
     },
     {
       "kind": "ImageStream",
-      "apiVersion": "v1",
+      "apiVersion": "image.openshift.io/v1",
       "metadata": {
         "name": "${NAME}",
         "annotations": {
@@ -79,7 +79,7 @@
     },
     {
       "kind": "BuildConfig",
-      "apiVersion": "v1",
+      "apiVersion": "build.openshift.io/v1",
       "metadata": {
         "name": "${NAME}",
         "annotations": {
@@ -139,7 +139,7 @@
     },
     {
       "kind": "DeploymentConfig",
-      "apiVersion": "v1",
+      "apiVersion": "apps.openshift.io/v1",
       "metadata": {
         "name": "${NAME}",
         "annotations": {

--- a/openshift/templates/django.json
+++ b/openshift/templates/django.json
@@ -251,8 +251,8 @@
     {
       "name": "PYTHON_VERSION",
       "displayName": "Version of Python Image",
-      "description": "Version of Python image to be used (3.6-ubi8, 3.8-ubi8, or latest).",
-      "value": "3.8-ubi8",
+      "description": "Version of Python image to be used (3.6-ubi8, 3.8-ubi8, 3.9-ubi8, or latest).",
+      "value": "3.9-ubi8",
       "required": true
     },
     {


### PR DESCRIPTION
- Use groupified apiVersion
- Update templates to Python 3.9

Should the 3.2.x branch be included in openshift instead of master (1.11.x)?

Should `SOURCE_REPOSITORY_REF` be defined as `3.2.x` by default so that master (1.11.x) does not get used anymore?
