### PR TITLE
New version of psycopg2-binary  works fine with Python 3.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django>=2.2.12,<3.0
 django-debug-toolbar==2.2
 gunicorn==20.0.4
-psycopg2-binary==2.8.6
+psycopg2-binary==2.9.5
 pytz==2020.1
 sqlparse==0.3.1
 whitenoise==5.1.0


### PR DESCRIPTION
Old version produces this:
```
---> Migrating database ...
Traceback (most recent call last):
  File "/opt/app-root/src/./manage.py", line 21, in <module>
    main()
  File "/opt/app-root/src/./manage.py", line 17, in main
    execute_from_command_line(sys.argv)
  File "/opt/app-root/lib64/python3.11/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/opt/app-root/lib64/python3.11/site-packages/django/core/management/__init__.py", line 375, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/opt/app-root/lib64/python3.11/site-packages/django/core/management/base.py", line 323, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/opt/app-root/lib64/python3.11/site-packages/django/core/management/base.py", line 361, in execute
    self.check()
  File "/opt/app-root/lib64/python3.11/site-packages/django/core/management/base.py", line 387, in check
    all_issues = self._run_checks(
                 ^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/django/core/management/commands/migrate.py", line 65, in _run_checks
    issues.extend(super()._run_checks(**kwargs))
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/django/core/management/base.py", line 377, in _run_checks
    return checks.run_checks(**kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/django/core/checks/registry.py", line 72, in run_checks
    new_errors = check(app_configs=app_configs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/debug_toolbar/apps.py", line 18, in check_middleware
    from debug_toolbar.middleware import DebugToolbarMiddleware
  File "/opt/app-root/lib64/python3.11/site-packages/debug_toolbar/middleware.py", line 12, in <module>
    from debug_toolbar.toolbar import DebugToolbar
  File "/opt/app-root/lib64/python3.11/site-packages/debug_toolbar/toolbar.py", line 141, in <module>
    urlpatterns = DebugToolbar.get_urls()
                  ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/debug_toolbar/toolbar.py", line 134, in get_urls
    for panel_class in cls.get_panel_classes():
                       ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/debug_toolbar/toolbar.py", line 115, in get_panel_classes
    panel_classes = [
                    ^
  File "/opt/app-root/lib64/python3.11/site-packages/debug_toolbar/toolbar.py", line 116, in <listcomp>
    import_string(panel_path) for panel_path in dt_settings.get_panels()
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/django/utils/module_loading.py", line 17, in import_string
    module = import_module(module_path)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/debug_toolbar/panels/sql/__init__.py", line 1, in <module>
    from debug_toolbar.panels.sql.panel import SQLPanel  # noqa
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/debug_toolbar/panels/sql/panel.py", line 13, in <module>
    from debug_toolbar.panels.sql.tracking import unwrap_cursor, wrap_cursor
  File "/opt/app-root/lib64/python3.11/site-packages/debug_toolbar/panels/sql/tracking.py", line 12, in <module>
    from psycopg2._json import Json as PostgresJson
  File "/opt/app-root/lib64/python3.11/site-packages/psycopg2/__init__.py", line 51, in <module>
    from psycopg2._psycopg import (                     # noqa
SystemError: initialization of _psycopg raised unreported exception
```