### PR TITLE
End of life notice by redhat

### DIFF
--- a/openshift/templates/django-postgresql-persistent.json
+++ b/openshift/templates/django-postgresql-persistent.json
@@ -441,7 +441,7 @@
       "name": "PYTHON_VERSION",
       "displayName": "Version of Python Image",
       "description": "Version of Python image to be used (3.6-ubi8, 3.8-ubi7, 3.8-ubi8, or latest).",
-      "value": "3.8-ubi8",
+      "value": "3.9",
       "required": true
     },
     {

--- a/openshift/templates/django-postgresql.json
+++ b/openshift/templates/django-postgresql.json
@@ -422,7 +422,7 @@
       "name": "PYTHON_VERSION",
       "displayName": "Version of Python Image",
       "description": "Version of Python image to be used (3.6-ubi8, 3.8-ubi7, 3.8-ubi8, or latest).",
-      "value": "3.8-ubi8",
+      "value": "3.9",
       "required": true
     },
     {

--- a/openshift/templates/django.json
+++ b/openshift/templates/django.json
@@ -252,7 +252,7 @@
       "name": "PYTHON_VERSION",
       "displayName": "Version of Python Image",
       "description": "Version of Python image to be used (3.6-ubi8, 3.8-ubi7, 3.8-ubi8, or latest).",
-      "value": "3.8-ubi8",
+      "value": "3.9",
       "required": true
     },
     {


### PR DESCRIPTION
Redhat won't support the current version of Python, and they suggest updating the python version.
https://catalog.redhat.com/software/containers/ubi8/python-39/6065b24eb92fbda3a4c65d8f