### PR TITLE
Use RHEL-9.4.0-Nightly compose.

### DIFF
--- a/.github/workflows/openshift-tests.yml
+++ b/.github/workflows/openshift-tests.yml
@@ -20,11 +20,11 @@ jobs:
       - uses: sclorg/testing-farm-as-github-action@main
         with:
           api_key: ${{ secrets.TF_INTERNAL_API_KEY }}
-          compose: "RHEL-8.8.0-Nightly"
+          compose: "RHEL-9.4.0-Nightly"
           git_url: "https://gitlab.cee.redhat.com/platform-eng-core-services/sclorg-tmt-plans"
           git_ref: "master"
           tf_scope: "private"
-          tmt_plan_regex: "rhel8-openshift-4"
+          tmt_plan_regex: "rhel9-openshift-pytest"
           update_pull_request_status: true
-          pull_request_status_name: "RHEL8-OpenShift-4 - imagestream test ${{ matrix.version }}"
-          variables: "REPO_URL=${{ github.server_url }}/${{ github.repository }};REPO_NAME=${{ github.repository }};PR_NUMBER=${{ github.event.issue.number }};OS=rhel8;SINGLE_VERSION=${{ matrix.version }};TEST_NAME=test-openshift-4"
+          pull_request_status_name: "RHEL9-OpenShift-4 - imagestream test ${{ matrix.version }}"
+          variables: "REPO_URL=${{ github.server_url }}/${{ github.repository }};REPO_NAME=${{ github.repository }};PR_NUMBER=${{ github.event.issue.number }};OS=rhel9;SINGLE_VERSION=${{ matrix.version }};TEST_NAME=test-openshift-pytest"

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
-.PHONY: test-openshift-4
-test-openshift-4:
-	cd tests && PYTHONPATH=$(CURDIR) python3 -m pytest --verbose --color=yes --showlocals .
+.PHONY: test-openshift-pytest
+test-openshift-pytest:
+	cd tests && PYTHONPATH=$(CURDIR) python3.12 -m pytest -s -rA --showlocals -vv test_django*.py


### PR DESCRIPTION
Use TMT plan that contains support for Python-3.12 and also installs container-ci-suite for testing this example repository.

Replace target in Makefile from test-openshift-4 to test-openshift-pytest

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
