### PR TITLE
Update psycopg2-binary dependency to 2.9.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django>=4.2,<5.0
 django-debug-toolbar==3.2.1
 gunicorn==20.1.0
-psycopg2-binary==2.9.5
+psycopg2-binary==2.9.10
 pytz==2021.1
 sqlparse==0.4.1
 whitenoise==5.2.0


### PR DESCRIPTION
Version 2.9.10 is the first one with pre-built wheels for Python 3.13.
