### PR TITLE
Bump psycopg2-binary to support Python 3.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 django>=1.11,<1.12
 django-debug-toolbar==1.11.1
 gunicorn==19.5.0
-psycopg2-binary==2.8.5
+psycopg2-binary==2.9.10
 whitenoise==3.3.1


### PR DESCRIPTION
In OCP 4.16 openshift/python:latest is now 3.11 instead of 3.8 and no longer builds with the old psycopg2
